### PR TITLE
Add explanation for workaround in case a third-party library uses tikzplotlib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,24 @@ to install.
     The command will remove points that are outside the axes limits, simplify curves and
     reduce point density for the specified target resolution.
 
-    The feature originated from the
-    [tikzplotlib](https://github.com/nschloe/tikzplotlib) project.
+## matplot2tikz vs. tikzplotlib
+
+This matplot2tikz library originated from the [tikzplotlib](https://github.com/nschloe/tikzplotlib)
+project.
+The reason a new library has been created is because tikzplotlib is no longer maintained and 
+maintainance could only be done by the single owner of the tikzplotlib library.
+If you need to use third-party code that already depends on tikzplotlib, it is suggested to change
+the tikzplotlib dependency to matplot2tikz. 
+If this is not possible, a workaround is to put the following code *before* importing the 
+third-party code:
+
+   ```
+   import sys
+   import matplot2tikz
+   sys.modules["tikzplotlib"] = matplot2tikz
+   # Do other imports, e.g., using `import my_third_party_library`
+   # If tikzplotlib is used in this library, it will automatically use matplot2tikz instead.
+   ```
 
 ## Contributing
 


### PR DESCRIPTION
Resolves #23 