### PR TITLE
Fix mypy arg-type error in test_line_collection.py

### DIFF
--- a/tests/test_line_collection.py
+++ b/tests/test_line_collection.py
@@ -28,8 +28,8 @@ def plot() -> Figure:
 
     # We need to set the plot limits, they will not autoscale
     ax = plt.axes()
-    ax.set_xlim((np.amin(x), np.amax(x)))
-    ax.set_ylim((np.amin(np.amin(ys)), np.amax(np.amax(ys))))
+    ax.set_xlim((float(np.amin(x)), float(np.amax(x))))
+    ax.set_ylim((float(np.amin(np.amin(ys))), float(np.amax(np.amax(ys)))))
 
     # colors is sequence of rgba tuples
     # linestyle is a string or dash tuple. Legal string values are


### PR DESCRIPTION
Wraps `np.amin()`/`np.amax()` calls in `float()` in `test_line_collection.py` to fix a mypy `arg-type` error when passing numpy scalar types to `set_xlim()`/`set_ylim()`.

All checks pass: `tox -e lint,py314` (ruff format, ruff check, mypy, 113/113 tests).