### PR TITLE
Use 'rel axis cs' for text with transAxes transform

### DIFF
--- a/src/matplot2tikz/_text.py
+++ b/src/matplot2tikz/_text.py
@@ -95,7 +95,11 @@ def _get_tikz_pos(data: TikzData, obj: Text, content: list[str]) -> str:
     if isinstance(pos, str):
         return pos
     if obj.axes:
-        # If the coordinates are relative to an axis, use `axis cs`.
+        # Check if the text uses axes-relative coordinates (transform=ax.transAxes).
+        # In that case, use `rel axis cs` instead of `axis cs`.
+        transform = obj.get_transform()
+        if transform == obj.axes.transAxes:
+            return f"(rel axis cs:{pos[0]:{data.float_format}},{pos[1]:{data.float_format}})"
         return f"(axis cs:{pos[0]:{data.float_format}},{pos[1]:{data.float_format}})"
     # relative to the entire figure, it's a getting a littler harder. See
     # <http://tex.stackexchange.com/a/274902/13262> for a solution to the

--- a/tests/test_fancybox_reference.tex
+++ b/tests/test_fancybox_reference.tex
@@ -28,7 +28,7 @@ ytick style={color=black}
 --(axis cs:0.2,0.4)
 .. controls (axis cs:0.2,0.33333333) and (axis cs:0.23333333,0.3) .. (axis cs:0.3,0.3)
 --cycle;
-\draw (axis cs:0.1,0.8) node[
+\draw (rel axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,
@@ -63,7 +63,7 @@ ytick style={color=black}
 --(axis cs:0.2,0.5)
 .. controls (axis cs:0.2,0.36666667) and (axis cs:0.26666667,0.3) .. (axis cs:0.4,0.3)
 --cycle;
-\draw (axis cs:0.1,0.8) node[
+\draw (rel axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,
@@ -99,7 +99,7 @@ ytick style={color=black}
 --(axis cs:0.1,0.4)
 .. controls (axis cs:0.1,0.26666667) and (axis cs:0.16666667,0.2) .. (axis cs:0.3,0.2)
 --cycle;
-\draw (axis cs:0.1,0.8) node[
+\draw (rel axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,
@@ -135,7 +135,7 @@ ytick style={color=black}
 --(axis cs:0,0.4)
 .. controls (axis cs:0,0.3) and (axis cs:0.1,0.25) .. (axis cs:0.3,0.25)
 --cycle;
-\draw (axis cs:0.1,0.8) node[
+\draw (rel axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,


### PR DESCRIPTION
Fixes #52

## Problem
When \x.text()\ uses \	ransform=ax.transAxes\, the coordinates are relative to the axes (0–1 range). However, the generated TikZ code was using \xis cs:\ which interprets them as data coordinates, placing the text at the wrong position.

**Before (incorrect):**
\\\latex
\draw (axis cs:0.05,0.95) node[...]
\\\

**After (correct):**
\\\latex
\draw (rel axis cs:0.05,0.95) node[...]
\\\

## Fix
In \_text.py\'s \_get_tikz_pos()\, detect when the text object's transform is \x.transAxes\ and emit \el axis cs:\ instead of \xis cs:\. Updated \	est_fancybox_reference.tex\ (4 occurrences) to match the corrected output.

All tests pass (113/113), ruff and mypy clean.