### PR TITLE
Upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/main_coverage.yaml
+++ b/.github/workflows/main_coverage.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -26,7 +26,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: python-package-distributions
         path: dist/
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.11
       # We just need one modern Python version to run the 'tox' command itself.
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 


### PR DESCRIPTION
Fixes #60

## Problem
All three GitHub workflows produce the deprecation warning:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Fix
Updated all action versions to their Node.js 24-compatible releases:

| Action | Before | After |
|---|---|---|
| \ctions/checkout\ | \@v4\ | \@v6\ |
| \ctions/setup-python\ | \@v5\ | \@v6\ |
| \ctions/upload-artifact\ | \@v4\ | \@v6\ |
| \ctions/download-artifact\ | \@v4\ | \@v6\ |

All three workflow files updated: \	ests.yaml\, \main_coverage.yaml\, \publish-to-pypi.yaml\.