### PR TITLE
Add support for AnchoredText conversion to TikZ

### DIFF
--- a/src/matplot2tikz/_save.py
+++ b/src/matplot2tikz/_save.py
@@ -16,6 +16,7 @@ from matplotlib.figure import Figure
 from matplotlib.image import AxesImage
 from matplotlib.legend import Legend
 from matplotlib.lines import Line2D
+from matplotlib.offsetbox import AnchoredText
 from matplotlib.patches import Patch
 from matplotlib.spines import Spine
 from matplotlib.text import Text
@@ -421,6 +422,7 @@ def _recurse(data: TikzData, obj: Artist) -> list:
                 (AxesImage, img.draw_image),
                 (Patch, _patch.draw_patch),
                 (Collection, _draw_collection),
+                (AnchoredText, _text.draw_anchored_text),
                 (Text, _text.draw_text),
             ):
                 if isinstance(child, child_type):

--- a/src/matplot2tikz/_text.py
+++ b/src/matplot2tikz/_text.py
@@ -12,6 +12,8 @@ from matplotlib.text import Annotation, Text
 from . import _color
 
 if TYPE_CHECKING:
+    from matplotlib.offsetbox import AnchoredText
+
     from ._tikzdata import TikzData
 
 
@@ -85,6 +87,95 @@ def draw_text(data: TikzData, obj: Text) -> list[str]:
     props = ",\n  ".join(properties)
     text = " ".join([*style, text])
     content.append(f"\\draw {tikz_pos} node[\n  {props}\n]{{{text}}};\n")
+    return content
+
+
+# Mapping from matplotlib loc codes to (rel axis cs x, rel axis cs y, anchor).
+_LOC_TO_TIKZ: dict[int, tuple[float, float, str]] = {
+    1: (0.98, 0.98, "north east"),
+    2: (0.02, 0.98, "north west"),
+    3: (0.02, 0.02, "south west"),
+    4: (0.98, 0.02, "south east"),
+    5: (0.98, 0.5, "east"),
+    6: (0.02, 0.5, "west"),
+    7: (0.98, 0.5, "east"),
+    8: (0.5, 0.02, "south"),
+    9: (0.5, 0.98, "north"),
+    10: (0.5, 0.5, "center"),
+}
+
+
+def draw_anchored_text(data: TikzData, obj: AnchoredText) -> list[str]:
+    """Convert a matplotlib AnchoredText to TikZ.
+
+    :return: Content for tikz plot.
+    """
+    # Extract the Text object(s) from the AnchoredText's TextArea.
+    text_children = [c for c in obj.txt.get_children() if isinstance(c, Text)]
+    if not text_children:
+        return []
+
+    content: list[str] = []
+    ff = data.float_format
+
+    x, y, anchor = _LOC_TO_TIKZ.get(obj.loc, (0.5, 0.5, "center"))
+    tikz_pos = f"(rel axis cs:{x:{ff}},{y:{ff}})"
+
+    for text_obj in text_children:
+        text = text_obj.get_text()
+        if not text:
+            continue
+
+        properties: list[str] = []
+        style: list[str] = []
+
+        properties.append(f"anchor={anchor}")
+
+        # Font scaling
+        size = text_obj.get_fontsize()
+        if isinstance(size, str):
+            size = font_scalings[size]
+        scaling = 0.5 * size / data.font_size
+        if scaling != 1.0:
+            properties.append(f"scale={scaling:{ff}}")
+
+        # Bounding box from the AnchoredText's patch
+        bbox = obj.patch
+        if bbox is not None and bbox.get_visible():
+            _bbox(data, bbox, properties, scaling)
+
+        # Text color
+        converter = mpl.colors.ColorConverter()
+        col, _ = _color.mpl_color2xcolor(data, converter.to_rgb(text_obj.get_color()))
+        properties.append(f"text={col}")
+        properties.append("rotate=0.0")
+
+        # Font style
+        if text_obj.get_fontstyle() == "italic":
+            style.append("\\itshape")
+
+        weight = text_obj.get_fontweight()
+        min_weight_bold = 550
+        if weight in [
+            "semibold",
+            "demibold",
+            "demi",
+            "bold",
+            "heavy",
+            "extra bold",
+            "black",
+        ] or (isinstance(weight, int) and weight > min_weight_bold):
+            style.append("\\bfseries")
+
+        if "\n" in text:
+            ha = text_obj.get_horizontalalignment()
+            properties.append(f"align={ha}")
+            text = text.replace("\n ", "\\\\")
+
+        props = ",\n  ".join(properties)
+        text = " ".join([*style, text])
+        content.append(f"\\draw {tikz_pos} node[\n  {props}\n]{{{text}}};\n")
+
     return content
 
 

--- a/tests/test_anchored_text.py
+++ b/tests/test_anchored_text.py
@@ -1,0 +1,19 @@
+"""Test for AnchoredText conversion (issue #53)."""
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+from matplotlib.offsetbox import AnchoredText
+
+from .helpers import assert_equality
+
+
+def plot() -> Figure:
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 4, 9])
+    at = AnchoredText("Test label", loc="upper left")
+    ax.add_artist(at)
+    return fig
+
+
+def test() -> None:
+    assert_equality(plot, "test_anchored_text_reference.tex")

--- a/tests/test_anchored_text_reference.tex
+++ b/tests/test_anchored_text_reference.tex
@@ -1,0 +1,34 @@
+\begin{tikzpicture}
+
+\definecolor{darkgray176}{RGB}{176,176,176}
+\definecolor{steelblue31119180}{RGB}{31,119,180}
+
+\begin{axis}[
+tick align=outside,
+tick pos=left,
+x grid style={darkgray176},
+xmin=0.9, xmax=3.1,
+xtick style={color=black},
+y grid style={darkgray176},
+ymin=0.6, ymax=9.4,
+ytick style={color=black}
+]
+\addplot [semithick, steelblue31119180]
+table {%
+1 1
+2 4
+3 9
+};
+\draw (rel axis cs:0.02,0.98) node[
+  anchor=north west,
+  scale=0.5,
+  fill=white,
+  draw=black,
+  line width=0.4pt,
+  inner sep=0pt,
+  text=black,
+  rotate=0.0
+]{Test label};
+\end{axis}
+
+\end{tikzpicture}


### PR DESCRIPTION
Fixes #53

## Problem
`AnchoredText` objects from `matplotlib.offsetbox` were silently ignored during conversion, producing a warning:
`
Don't know how to handle artist AnchoredText(...)
`

## Solution
- Added `AnchoredText` to the dispatch loop in `_save.py::_recurse()` (placed before `Text` to ensure correct isinstance matching order).
- Implemented `draw_anchored_text()` in `_text.py` that:
  - Extracts `Text` children from the `AnchoredText`'s `TextArea`
  - Maps matplotlib's `loc` codes (1–10) to tikz `(rel axis cs:x,y)` positions with appropriate anchors via `_LOC_TO_TIKZ`
  - Handles bbox patch properties (fill color, edge color, line width)
  - Handles font size, weight, and color

## Test
Added `test_anchored_text.py` with a matching reference file. All existing tests continue to pass (114/114).

## Validation
- `tox -e lint` (ruff format, ruff check, mypy): all pass
- `tox -e py314` (pytest): 114/114 pass